### PR TITLE
Snap: grant android.permission.RECEIVE_BOOT_COMPLETED permisions

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -16,6 +16,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />


### PR DESCRIPTION
Log:
03-07 13:00:45.697  2812  2830 W BroadcastQueue: Permission Denial:
receiving Intent { act=android.intent.action.BOOT_COMPLETED
flg=0x9000010 (has extras) } to
org.cyanogenmod.snap/com.android.camera.DisableCameraReceiver requires
android.permission.RECEIVE_BOOT_COMPLETED due to sender null (uid 1000)

Change-Id: I55cd1c96ac1a06b644fc207c235f694c8a60da99